### PR TITLE
Fix warnings from -Wall -Wextra

### DIFF
--- a/xjjlibs/xjjc/xjjcuti.h
+++ b/xjjlibs/xjjc/xjjcuti.h
@@ -235,7 +235,7 @@ std::string xjjc::currenttime()
 {
   std::time_t t = std::time(0);   // get time now
   std::tm* now = std::localtime(&t);
-  char chartime[15]; // yyyymmdd-hhmmss
+  char chartime[29]; // yyyymmdd-hhmmss
   sprintf(chartime, "%d%s%d%d-%d%d%d", now->tm_year+1900, (now->tm_mon>=9?"":"0"), now->tm_mon+1, now->tm_mday,
           now->tm_hour, now->tm_min, now->tm_sec);
   return std::string(chartime);

--- a/xjjlibs/xjjroot/xjjrootuti.h
+++ b/xjjlibs/xjjroot/xjjrootuti.h
@@ -237,7 +237,8 @@ void xjjroot::drawtexgroup(Double_t x, Double_t y, std::vector<std::string> text
       if(!left) xx = x - colwid*(t%ncol);
       double yy = y - lspace*(t/ncol);
       if(!top) yy = y + lspace*(t/ncol);
-      Color_t cc = t<color.size()?color[t]:kBlack;
+      constexpr unsigned fallback = kBlack;
+      Color_t cc = t<color.size()?color[t]:fallback;
       drawtex(xx, yy, text[t].c_str(), tsize, align, font, cc);
     }
 }


### PR DESCRIPTION
The length of the string "%d%s..." can be theoretically 29 from the allowed
range of the input integers, so the compiler complains about possible overflows.

g++ also doesn't consider enum type and unsigned to be equal, so we cast the type of kBlack first.